### PR TITLE
Add more info to description meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,17 +5,17 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="repometric landing page.">
+    <meta name="description" content="Repometric – reporting and analytics platform for your development process. It helps you analyze and lint the code inside your favorite IDE (Visual Studio Code, Atom) or integrate linterhub platform in your process.">
     <meta name="author" content="repometric">
-    
+
     <title>repometric</title>
-    
+
     <!-- opengraph -->
     <meta property="og:type" content="website">
     <meta property="og:title" content="repometric landing page.">
     <meta property="og:url" content="http://repometric.com">
     <meta property="og:image" content="http://repometric.com/images/share-cover.jpg">
-    
+
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="assets/raster/favicon/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">


### PR DESCRIPTION
PR for the issue https://github.com/repometric/landing/issues/8.

Issue: search engines ignore content of description meta tag because of a small amount of characters.

Solution: add more info text into description meta tag.